### PR TITLE
Autoloader Fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "php": ">=5.1.4"
     },
     "autoload": {
-        "psr-0": { "Net_URL2": "./" }
+        "psr-0": { "Net": "./" }
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
This fix will ensure that the `NET_URL2` folder is added to the composer `include_paths.php` file
