### PR TITLE
Add legacy include path option.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,9 @@
         "php": ">=5.1.4"
     },
     "autoload": {
-        "classmap": ["Net/URL2.php"]
+        "psr-0": {
+            "Net_URL2" : ""
+        }
     },
     "extra": {
         "branch-alias": {
@@ -43,5 +45,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=3.3.0"
-    }
+    },
+    "include-path": [
+        "./"
+    ]
 }


### PR DESCRIPTION
Other PEAR packages like HTTP_Request2 that depend on Net_URL2 expect the include path to be set.

Also switch the autoloader from classmap to psr-0.
