### PR TITLE
Add .gitattributes to exclude dev files from Composer package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+/.* export-ignore
+/docs/*.php export-ignore
+/tests/ export-ignore
+/package.xml export-ignore
+/phpunit.xml.dist export-ignore


### PR DESCRIPTION
This omits unnececary files from the deployed package. Especially when auditing packages for production deployment, or when versioning the `vendor/` directory, this helps reduce noise.

This package is currently being considered for bundling with <https://github.com/Wikipedia/mediawiki> ([vendor](https://github.com/wikimedia/mediawiki-vendor/)). The extraneous files from `Net_URL2` stood out in a local build as most other packages seem to exclude these kinds of files.