### PR TITLE
Fix _encodeData regexp

### DIFF
--- a/Net/URL2.php
+++ b/Net/URL2.php
@@ -1198,7 +1198,7 @@ class Net_URL2
     private function _encodeData($url)
     {
         return preg_replace_callback(
-            '([\x-\x20\x22\x3C\x3E\x7F-\xFF]+)',
+            '([\x00-\x20\x22\x3C\x3E\x7F-\xFF]+)',
             array($this, '_encodeCallback'), $url
         );
     }


### PR DESCRIPTION
\x was used shorthand for \x00. php v8.3.16 and v8.4.3 seem to not accept that any more. This failing example code demonstrates that:

  echo preg_match('/[\x-\x20]+/', "\x00");