### PR TITLE
Restore Phpunit Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
           ini-values: include_path=.:/usr/share/php:pear/usr/share/php
+          tools: composer:2.2
+      - name: Install dependencies
+        run: composer install
       - name: Run tests
         run: |
+          composer test
           pear run-tests -r tests/

--- a/composer.json
+++ b/composer.json
@@ -46,5 +46,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=3.3.0"
+    },
+    "scripts": {
+        "test": "phpunit"
     }
 }

--- a/package.xml
+++ b/package.xml
@@ -32,10 +32,10 @@ http://pear.php.net/dtd/package-2.0.xsd">
     <active>no</active>
   </lead>
 
-  <date>2016-04-19</date>
+  <date>2017-08-25</date>
   <time>00:00:00</time>
   <version>
-    <release>2.2.1</release>
+    <release>2.2.2</release>
     <api>2.1.0</api>
   </version>
   <stability>
@@ -44,10 +44,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
   </stability>
   <license uri="https://spdx.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
   <notes>
-    * Fix: Correct earlier regex delimiter
-    * Fix: Travis missing hhvm-nightly
-    * Fix: Travis PHP 5.2
-    * Fix: Correct case of method call name
+    * Fix: Set composer include path to keep other packages working
   </notes>
 
   <contents>
@@ -86,6 +83,22 @@ http://pear.php.net/dtd/package-2.0.xsd">
   </dependencies>
   <phprelease />
   <changelog>
+    <release>
+      <date>2017-08-25</date>
+      <time>00:00:00</time>
+      <version>
+        <release>2.2.2</release>
+        <api>2.1.0</api>
+      </version>
+      <stability>
+        <release>stable</release>
+        <api>stable</api>
+      </stability>
+      <license uri="https://spdx.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
+      <notes>
+        * Fix: Set composer include path to keep other packages working
+      </notes>
+    </release>
     <release>
       <date>2016-04-19</date>
       <time>00:00:00</time>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="Net/URL2.php"
+<phpunit bootstrap="tests/bootstrap.php"
          colors="false"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"

--- a/tests/Net/URL2Test.php
+++ b/tests/Net/URL2Test.php
@@ -212,7 +212,7 @@ class Net_URL2Test extends PHPUnit_Framework_TestCase
      * @see testResolveUrls
      * @return array
      */
-    public function provideResolveUrls()
+    public static function provideResolveUrls()
     {
         return array(
             array(
@@ -283,6 +283,7 @@ class Net_URL2Test extends PHPUnit_Framework_TestCase
      * @covers Net_URL2::resolve
      * @return void
      */
+    #[PHPUnit\Framework\Attributes\DataProvider('provideResolveUrls')]
     public function testResolveUrls($baseURL, array $relativeAbsolutePairs,
         array $options = array()
     ) {
@@ -468,7 +469,7 @@ class Net_URL2Test extends PHPUnit_Framework_TestCase
      * @link http://tools.ietf.org/html/rfc3986#section-1.1.2
      * @see  testExampleUri
      */
-    public function provideExampleUri()
+    public static function provideExampleUri()
     {
         return array(
             array('ftp://ftp.is.co.za/rfc/rfc1808.txt'),
@@ -492,6 +493,7 @@ class Net_URL2Test extends PHPUnit_Framework_TestCase
      * @link         http://tools.ietf.org/html/rfc3986#section-1.1.2
      * @see          testComponentRecompositionAndNormalization
      */
+    #[PHPUnit\Framework\Attributes\DataProvider('provideExampleUri')]
     public function testExampleUri($uri)
     {
         $url = new Net_URL2($uri);
@@ -507,7 +509,7 @@ class Net_URL2Test extends PHPUnit_Framework_TestCase
      * @see testRemoveDotSegments
      * @return array
      */
-    public function providePath()
+    public static function providePath()
     {
         // The numbers behind are in reference to sections
         // in RFC 3986 5.2.4. Remove Dot Segments
@@ -542,6 +544,7 @@ class Net_URL2Test extends PHPUnit_Framework_TestCase
      * @covers Net_URL2::removeDotSegments
      * @return void
      */
+    #[PHPUnit\Framework\Attributes\DataProvider('providePath')]
     public function testRemoveDotSegments($path, $assertion)
     {
         $this->assertEquals($assertion, Net_URL2::removeDotSegments($path));
@@ -570,7 +573,7 @@ class Net_URL2Test extends PHPUnit_Framework_TestCase
      * @see testGetQueryVariables
      * @return array
      */
-    public function provideQueryStrings()
+    public static function provideQueryStrings()
     {
         // If the second (expected) value is set or not null, parse_str() differs.
         // Notes on PHP differences with each entry/block
@@ -632,6 +635,7 @@ class Net_URL2Test extends PHPUnit_Framework_TestCase
      * @covers       Net_URL2::_queryKeyBracketOffset
      * @return void
      */
+    #[PHPUnit\Framework\Attributes\DataProvider('provideQueryStrings')]
     public function testGetQueryVariables($query, $expected = null,
         array $options = array()
     ) {
@@ -663,7 +667,7 @@ class Net_URL2Test extends PHPUnit_Framework_TestCase
      * @return array
      * @see testHostAndPort
      */
-    public function provideHostAndPort()
+    public static function provideHostAndPort()
     {
         return array(
             array('[::1]', '[::1]', false),
@@ -699,6 +703,7 @@ class Net_URL2Test extends PHPUnit_Framework_TestCase
      * @link         http://tools.ietf.org/html/rfc3986#section-3.2
      * @link         http://tools.ietf.org/html/rfc3986#section-3.2.3
      */
+    #[PHPUnit\Framework\Attributes\DataProvider('provideHostAndPort')]
     public function testHostAndPort($authority, $expectedHost, $expectedPort)
     {
         $uri = "http://{$authority}";
@@ -762,6 +767,8 @@ class Net_URL2Test extends PHPUnit_Framework_TestCase
             Net_URL2::removeDotSegments($nonStringObject);
         } catch (PHPUnit_Framework_Error $error) {
             $this->addToAssertionCount(1);
+        } catch (Throwable $error) {
+            $this->addToAssertionCount(1);
         }
 
         if (!isset($error)) {
@@ -816,7 +823,7 @@ class Net_URL2Test extends PHPUnit_Framework_TestCase
      * @see testConstructSelf
      * @return array
      */
-    public function provideEquivalentUrlLists()
+    public static function provideEquivalentUrlLists()
     {
         return array(
             // String equivalence:
@@ -853,6 +860,7 @@ class Net_URL2Test extends PHPUnit_Framework_TestCase
      *
      * @dataProvider provideEquivalentUrlLists
      */
+    #[PHPUnit\Framework\Attributes\DataProvider('provideEquivalentUrlLists')]
     public function testNormalize()
     {
         $urls = func_get_args();
@@ -897,7 +905,7 @@ class Net_URL2Test extends PHPUnit_Framework_TestCase
      * @return array
      * @see testComponentRecompositionAndNormalization
      */
-    public function provideComposedAndNormalized()
+    public static function provideComposedAndNormalized()
     {
         return array(
             array(''),
@@ -926,6 +934,7 @@ class Net_URL2Test extends PHPUnit_Framework_TestCase
      * @link         https://pear.php.net/bugs/bug.php?id=20418
      * @see          testExampleUri
      */
+    #[PHPUnit\Framework\Attributes\DataProvider('provideComposedAndNormalized')]
     public function testComponentRecompositionAndNormalization($uri)
     {
         $url = new Net_URL2($uri);
@@ -942,6 +951,7 @@ class Net_URL2Test extends PHPUnit_Framework_TestCase
      * @coversNothing
      * @return void
      */
+    #[PHPUnit\Framework\Attributes\DataProvider('provideEquivalentUrlLists')]
     public function testConstructSelf()
     {
         $urls = func_get_args();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Net_URL2, a class representing a URL as per RFC 3986.
+ *
+ * PHP version 5
+ *
+ * @category Networking
+ * @package  Net_URL2
+ * @author   Some Pear Developers <pear@php.net>
+ * @license  https://spdx.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @link     https://tools.ietf.org/html/rfc3986
+ */
+
+if (!class_exists('PHPUnit_Framework_TestCase'))
+{
+    class_alias('PHPUnit\Framework\TestCase', 'PHPUnit_Framework_TestCase');
+}
+
+require __DIR__ . '/../Net/URL2.php';


### PR DESCRIPTION
Since Travis is gone we've missed the opportunity to run the Phpunit test-cases.

This pull request restores the test-suite in the current matrix on Microsoft Github.

To test locally, run `composer install` and then `composer test`.