### PR TITLE
Update URL2.php

### DIFF
--- a/Net/URL2.php
+++ b/Net/URL2.php
@@ -1198,7 +1198,7 @@ class Net_URL2
     private function _encodeData($url)
     {
         return preg_replace_callback(
-            '([\x-\x20\x22\x3C\x3E\x7F-\xFF]+)',
+            '([\x00-\x20\x22\x3C\x3E\x7F-\xFF]+)',
             array($this, '_encodeCallback'), $url
         );
     }


### PR DESCRIPTION
PCRE2 10.45 strictly enforces the use of \x00 instead of the shorthand form \x (ref. https://github.com/PCRE2Project/pcre2/blob/pcre2-10.45/NEWS). This breaks URL encoding in Net_URL2.