### PR TITLE
Fix tests for PHPUnit 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "source": "https://github.com/pear/Net_URL2"
     },
     "require": {
-        "php": ">=5.1.4"
+        "php": ">=5.3"
     },
     "autoload": {
         "classmap": ["Net/URL2.php"]
@@ -45,7 +45,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": ">=3.3.0"
+        "phpunit/phpunit": ">=4.8"
     },
     "scripts": {
         "test": "phpunit"

--- a/tests/Net/URL2Test.php
+++ b/tests/Net/URL2Test.php
@@ -863,7 +863,7 @@ class Net_URL2Test extends PHPUnit_Framework_TestCase
      * @dataProvider provideEquivalentUrlLists
      */
     #[PHPUnit\Framework\Attributes\DataProvider('provideEquivalentUrlLists')]
-    public function testNormalize(string $urlOne, string $urlTwo, bool $identical)
+    public function testNormalize($urlOne, $urlTwo, $identical)
     {
         $urlOne = new Net_Url2($urlOne);
         $urlTwo = new Net_Url2($urlTwo);
@@ -951,7 +951,7 @@ class Net_URL2Test extends PHPUnit_Framework_TestCase
      * @return void
      */
     #[PHPUnit\Framework\Attributes\DataProvider('provideEquivalentUrlLists')]
-    public function testConstructSelf(string $urlOne, string $urlTwo, bool $identical)
+    public function testConstructSelf($urlOne, $urlTwo, $identical)
     {
         $urlOne = new Net_Url2($urlOne);
         $urlOneExtended = new Net_Url2($urlOne);


### PR DESCRIPTION
While running phpunit tests I got some concerning warnings, I fixed them
```
1) Net_URL2Test::testNormalize
* Data set #0 provided by Net_URL2Test::provideEquivalentUrlLists has more arguments (2) than the test method accepts (1)

* Data set #1 provided by Net_URL2Test::provideEquivalentUrlLists has more arguments (2) than the test method accepts (1)

* Data set #2 provided by Net_URL2Test::provideEquivalentUrlLists has more arguments (2) than the test method accepts (1)

* Data set #3 provided by Net_URL2Test::provideEquivalentUrlLists has more arguments (2) than the test method accepts (1)

* Data set #4 provided by Net_URL2Test::provideEquivalentUrlLists has more arguments (4) than the test method accepts (1)

* Data set #5 provided by Net_URL2Test::provideEquivalentUrlLists has more arguments (2) than the test method accepts (1)

* Data set #6 provided by Net_URL2Test::provideEquivalentUrlLists has more arguments (2) than the test method accepts (1)

/mnt/Dev/@debian/@qa/php-net-url2/Net_URL2-2.2.3/tests/Net/URL2Test.php:864

2) Net_URL2Test::testConstructSelf
* Data set #0 provided by Net_URL2Test::provideEquivalentUrlLists has more arguments (2) than the test method accepts (0)

* Data set #1 provided by Net_URL2Test::provideEquivalentUrlLists has more arguments (2) than the test method accepts (0)

* Data set #2 provided by Net_URL2Test::provideEquivalentUrlLists has more arguments (2) than the test method accepts (0)

* Data set #3 provided by Net_URL2Test::provideEquivalentUrlLists has more arguments (2) than the test method accepts (0)

* Data set #4 provided by Net_URL2Test::provideEquivalentUrlLists has more arguments (4) than the test method accepts (0)

* Data set #5 provided by Net_URL2Test::provideEquivalentUrlLists has more arguments (2) than the test method accepts (0)

* Data set #6 provided by Net_URL2Test::provideEquivalentUrlLists has more arguments (2) than the test method accepts (0)

/mnt/Dev/@debian/@qa/php-net-url2/Net_URL2-2.2.3/tests/Net/URL2Test.php:953
```
 